### PR TITLE
perf: run a chart's bundled image pushers concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ Bazel rules for [Helm](https://helm.sh/).
 ## Documentation
 
 https://periareon.github.io/rules_helm/
+
+## Environment variables
+
+### `RULES_HELM_IMAGE_PUSH_CONCURRENCY`
+
+How many of a chart's bundled image pushers run at once. Defaults to `4`, and applies to
+[helm_push](https://periareon.github.io/rules_helm/defs.html#helm_push),
+[helm_push_images](https://periareon.github.io/rules_helm/defs.html#helm_push_images),
+[helm_install](https://periareon.github.io/rules_helm/defs.html#helm_install) and
+[helm_upgrade](https://periareon.github.io/rules_helm/defs.html#helm_upgrade).
+
+Each image is pushed by its own process, which authenticates with the registry before it looks at
+anything, so a chart with many images spends most of the push waiting rather than transferring.
+Running the pushers concurrently keeps that cost from scaling with the image count.
+
+Set it to `1` to push one image at a time. A serial run also streams each pusher's output live on
+its own streams, instead of capturing it and replaying it as a block once the pusher exits, which
+makes a single failing push easier to follow.
+
+Values that are not a positive integer are ignored with a warning.

--- a/helm/private/helm_utils/BUILD.bazel
+++ b/helm/private/helm_utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "helm_utils",
@@ -8,4 +8,11 @@ go_library(
     deps = [
         "@rules_go//go/runfiles",
     ],
+)
+
+go_test(
+    name = "helm_utils_test",
+    srcs = ["helm_utils_test.go"],
+    embed = [":helm_utils"],
+    deps = ["@rules_go//go/runfiles"],
 )

--- a/helm/private/helm_utils/helm_utils.go
+++ b/helm/private/helm_utils/helm_utils.go
@@ -2,16 +2,144 @@ package helm_utils
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
 )
+
+// ImagePushConcurrencyEnvVar names the environment variable that overrides how
+// many image pushers run concurrently. Set it to 1 to push serially.
+const ImagePushConcurrencyEnvVar = "RULES_HELM_IMAGE_PUSH_CONCURRENCY"
+
+// defaultImagePushConcurrency bounds concurrent pushers by default. It
+// multiplies an already-parallel conversation rather than starting one: crane
+// uploads a single image's layers 4 at a time, and nests that again per child for
+// a multi-platform index. Kept modest because a throttled push is only retried
+// when the registry answers with a docker-distribution body naming
+// TOOMANYREQUESTS; a bare HTTP 429 matches neither go-containerregistry retry
+// path and fails the push outright.
+const defaultImagePushConcurrency = 4
+
+// imagePushConcurrency resolves the concurrency limit for a run of n pushers.
+// An unparsable or non-positive override falls back to the default.
+func imagePushConcurrency(n int) int {
+	limit := defaultImagePushConcurrency
+	if raw, ok := os.LookupEnv(ImagePushConcurrencyEnvVar); ok {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			log.Printf("WARNING: Ignoring invalid %s=%q, using %d.", ImagePushConcurrencyEnvVar, raw, limit)
+		} else {
+			limit = parsed
+		}
+	}
+
+	if limit > n {
+		return n
+	}
+
+	return limit
+}
+
+// RunImagePushers runs each image pusher executable, up to
+// `RULES_HELM_IMAGE_PUSH_CONCURRENCY` at a time.
+//
+// Every pusher is announced on stderr before it starts, so a slow or stalled
+// push is identifiable while it is still running.
+//
+// When more than one pusher may run at a time their output would otherwise
+// collide line by line, so each pusher's stdout and stderr are captured and
+// replayed to stdout as a single block once it exits. At a concurrency of 1
+// nothing can collide and the pusher writes through to stdout and stderr live,
+// unbuffered and on their original streams.
+//
+// Every pusher runs even if an earlier one fails; the returned error joins all
+// failures, in the order the pushers were given.
+//
+// Parameters:
+//   - pushers: Paths to image pusher executables, already resolved to real files.
+//
+// Returns:
+//   - error: The joined failures of every pusher that did not exit successfully.
+func RunImagePushers(pushers []string) error {
+	if len(pushers) == 0 {
+		return nil
+	}
+
+	r, err := runfiles.New()
+	if err != nil {
+		return fmt.Errorf("failed to load runfiles: %w", err)
+	}
+
+	// Shared across pushers: exec.Cmd copies it into a new slice and never
+	// writes through this one.
+	env := append(os.Environ(), r.Env()...)
+
+	concurrency := imagePushConcurrency(len(pushers))
+	streamLive := concurrency == 1
+
+	var wg sync.WaitGroup
+	var outputMutex sync.Mutex
+	semaphore := make(chan struct{}, concurrency)
+	errs := make([]error, len(pushers))
+
+	for i, pusher := range pushers {
+		wg.Add(1)
+		go func(i int, pusher string) {
+			defer wg.Done()
+
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			// Announced before the process starts, so the run is never silent
+			// and a push that hangs names itself.
+			outputMutex.Lock()
+			log.Printf("Running image pusher: %s", pusher)
+			outputMutex.Unlock()
+
+			cmd := exec.Command(pusher)
+			cmd.Env = env
+
+			var output bytes.Buffer
+			if streamLive {
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+			} else {
+				cmd.Stdout = &output
+				cmd.Stderr = &output
+			}
+
+			runErr := cmd.Run()
+
+			if !streamLive {
+				outputMutex.Lock()
+				// Header and body share one stream so a block cannot be split
+				// by another pusher's output.
+				fmt.Fprintf(os.Stdout, "Output from image pusher %s:\n", pusher)
+				if _, err := output.WriteTo(os.Stdout); err != nil {
+					log.Printf("WARNING: Failed to write output of image pusher %s: %v", pusher, err)
+				}
+				outputMutex.Unlock()
+			}
+
+			if runErr != nil {
+				errs[i] = fmt.Errorf("failed to run image pusher %s: %w", pusher, runErr)
+			}
+		}(i, pusher)
+	}
+
+	wg.Wait()
+
+	return errors.Join(errs...)
+}
 
 // BuildHelmCommand constructs an exec.Cmd to run a Helm command with the specified arguments and plugins directory.
 // It takes the path to the Helm executable, a slice of arguments for the Helm command, and the path to the plugins directory.

--- a/helm/private/helm_utils/helm_utils_test.go
+++ b/helm/private/helm_utils/helm_utils_test.go
@@ -1,0 +1,363 @@
+package helm_utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+// clearImagePushConcurrency removes the override for the duration of the test,
+// so a value the developer has exported cannot decide the outcome. `t.Setenv`
+// has no unset form, but calling it registers the cleanup that puts their value
+// back.
+func clearImagePushConcurrency(t *testing.T) {
+	t.Helper()
+
+	t.Setenv(ImagePushConcurrencyEnvVar, "")
+	if err := os.Unsetenv(ImagePushConcurrencyEnvVar); err != nil {
+		t.Fatalf("Failed to unset %s: %v", ImagePushConcurrencyEnvVar, err)
+	}
+}
+
+// requireImagePushers skips a test that cannot run outside Bazel.
+// RunImagePushers resolves the runfiles environment it hands to each pusher, and
+// the pusher stand-ins are shell scripts.
+func requireImagePushers(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("pusher stand-ins are shell scripts")
+	}
+	if _, err := runfiles.New(); err != nil {
+		t.Skipf("no runfiles, so image pushers cannot be run: %v", err)
+	}
+}
+
+func TestImagePushConcurrencyDefault(t *testing.T) {
+	clearImagePushConcurrency(t)
+
+	if got := imagePushConcurrency(100); got != defaultImagePushConcurrency {
+		t.Errorf("imagePushConcurrency(100) = %d, want %d", got, defaultImagePushConcurrency)
+	}
+}
+
+func TestImagePushConcurrencyClampsToPusherCount(t *testing.T) {
+	clearImagePushConcurrency(t)
+
+	if got := imagePushConcurrency(3); got != 3 {
+		t.Errorf("imagePushConcurrency(3) = %d, want 3", got)
+	}
+}
+
+func TestImagePushConcurrencyEnvOverride(t *testing.T) {
+	t.Setenv(ImagePushConcurrencyEnvVar, "2")
+
+	if got := imagePushConcurrency(100); got != 2 {
+		t.Errorf("imagePushConcurrency(100) = %d, want 2", got)
+	}
+}
+
+func TestImagePushConcurrencyInvalidEnvOverride(t *testing.T) {
+	for _, raw := range []string{"0", "-1", "many", ""} {
+		t.Run(fmt.Sprintf("value=%q", raw), func(t *testing.T) {
+			t.Setenv(ImagePushConcurrencyEnvVar, raw)
+
+			if got := imagePushConcurrency(100); got != defaultImagePushConcurrency {
+				t.Errorf("imagePushConcurrency(100) = %d, want %d", got, defaultImagePushConcurrency)
+			}
+		})
+	}
+}
+
+// writePusher creates an executable stand-in for an image pusher.
+func writePusher(t *testing.T, dir string, name string, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	script := "#!/usr/bin/env bash\nset -euo pipefail\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("Failed to write pusher %s: %v", path, err)
+	}
+
+	return path
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was
+// written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "stdout")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Failed to create capture file: %v", err)
+	}
+
+	original := os.Stdout
+	os.Stdout = file
+	defer func() {
+		os.Stdout = original
+		file.Close()
+	}()
+
+	fn()
+
+	if err := file.Sync(); err != nil {
+		t.Fatalf("Failed to sync capture file: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read capture file: %v", err)
+	}
+
+	return string(content)
+}
+
+func TestRunImagePushersNoPushers(t *testing.T) {
+	if err := RunImagePushers(nil); err != nil {
+		t.Errorf("RunImagePushers(nil) = %v, want nil", err)
+	}
+}
+
+func TestRunImagePushersRunsEveryPusher(t *testing.T) {
+	requireImagePushers(t)
+
+	dir := t.TempDir()
+	outputs := filepath.Join(dir, "outputs")
+	if err := os.Mkdir(outputs, 0o755); err != nil {
+		t.Fatalf("Failed to create outputs dir: %v", err)
+	}
+
+	var pushers []string
+	for i := 0; i < 5; i++ {
+		pushers = append(pushers, writePusher(t, dir, fmt.Sprintf("pusher%d", i),
+			fmt.Sprintf("touch %q\n", filepath.Join(outputs, fmt.Sprintf("ran%d", i)))))
+	}
+
+	captureStdout(t, func() {
+		if err := RunImagePushers(pushers); err != nil {
+			t.Errorf("RunImagePushers() = %v, want nil", err)
+		}
+	})
+
+	entries, err := os.ReadDir(outputs)
+	if err != nil {
+		t.Fatalf("Failed to read outputs dir: %v", err)
+	}
+	if len(entries) != len(pushers) {
+		t.Errorf("%d pushers ran, want %d", len(entries), len(pushers))
+	}
+}
+
+// Pushers must actually overlap in time, and each one's output must still land
+// as a single contiguous block.
+//
+// The barrier is driven by the test, not by the pushers watching each other:
+// every pusher reports that it started and then blocks until the test releases
+// it. That keeps the check off the wall clock. A machine too loaded to start all
+// the pushers promptly reports how many did start, rather than failing as though
+// the production code had stopped running them concurrently. Once released they
+// all write at once, which a naive implementation streaming straight to stdout
+// cannot keep contiguous.
+func TestRunImagePushersIsConcurrentWithoutInterleavingOutput(t *testing.T) {
+	requireImagePushers(t)
+
+	const (
+		pusherCount  = 4
+		linesPerPush = 200
+		marker       = "line"
+		barrierWait  = 30 * time.Second
+	)
+
+	dir := t.TempDir()
+	rendezvous := filepath.Join(dir, "rendezvous")
+	if err := os.Mkdir(rendezvous, 0o755); err != nil {
+		t.Fatalf("Failed to create rendezvous dir: %v", err)
+	}
+	release := filepath.Join(rendezvous, "release")
+
+	t.Setenv(ImagePushConcurrencyEnvVar, strconv.Itoa(pusherCount))
+
+	// Waiting on the release file uses a shell builtin, so a blocked pusher
+	// costs one `sleep` per poll rather than a pipeline of subprocesses.
+	var pushers []string
+	for i := 0; i < pusherCount; i++ {
+		pushers = append(pushers, writePusher(t, dir, fmt.Sprintf("pusher%d", i), fmt.Sprintf(`
+touch %[1]q/started%[2]d
+for _ in $(seq 1 6000); do
+  if [ -f %[3]q ]; then
+    for j in $(seq 1 %[4]d); do echo "p%[2]d %[5]s $j"; done
+    exit 0
+  fi
+  sleep 0.01
+done
+echo "timed out waiting for the test to release this pusher" >&2
+exit 1
+`, rendezvous, i, release, linesPerPush, marker)))
+	}
+
+	// Reported over a channel rather than through `t`: this goroutine can outlive
+	// a failed assertion, and logging from it after the test has finished panics.
+	type barrier struct {
+		started int
+		err     error
+	}
+	barrierDone := make(chan barrier, 1)
+	abandon := make(chan struct{})
+	defer close(abandon)
+
+	go func() {
+		deadline := time.Now().Add(barrierWait)
+		for {
+			count := 0
+			if entries, err := os.ReadDir(rendezvous); err == nil {
+				for _, entry := range entries {
+					if strings.HasPrefix(entry.Name(), "started") {
+						count++
+					}
+				}
+			}
+
+			if count >= pusherCount || time.Now().After(deadline) {
+				// Released even on timeout, so no pusher is left blocking on a
+				// barrier the test has already given up on.
+				barrierDone <- barrier{started: count, err: os.WriteFile(release, nil, 0o644)}
+				return
+			}
+
+			select {
+			case <-abandon:
+				// The pushers failed before reaching the barrier, so there is
+				// nothing left to release and no reason to wait out the deadline.
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+		}
+	}()
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = RunImagePushers(pushers)
+	})
+
+	// Checked before the barrier: a failure to run the pushers at all is the
+	// cause, and reporting "they did not run concurrently" on top of it would
+	// point at the wrong thing.
+	if runErr != nil {
+		t.Fatalf("RunImagePushers() = %v, want nil", runErr)
+	}
+
+	result := <-barrierDone
+	if result.err != nil {
+		t.Fatalf("Failed to write release file: %v", result.err)
+	}
+	if result.started < pusherCount {
+		t.Fatalf("only %d of %d pushers started within %s, so they did not run concurrently", result.started, pusherCount, barrierWait)
+	}
+
+	// Collapse the output to the pusher responsible for each body line.
+	var sequence []string
+	for _, line := range strings.Split(stdout, "\n") {
+		if !strings.Contains(line, marker) {
+			continue
+		}
+		sequence = append(sequence, strings.Fields(line)[0])
+	}
+
+	if len(sequence) != pusherCount*linesPerPush {
+		t.Fatalf("captured %d body lines, want %d", len(sequence), pusherCount*linesPerPush)
+	}
+
+	// One contiguous block per pusher means the owner changes exactly
+	// pusherCount-1 times.
+	transitions := 0
+	for i := 1; i < len(sequence); i++ {
+		if sequence[i] != sequence[i-1] {
+			transitions++
+		}
+	}
+	if transitions != pusherCount-1 {
+		t.Errorf("output interleaved: %d owner transitions, want %d", transitions, pusherCount-1)
+	}
+}
+
+func TestRunImagePushersJoinsAllFailures(t *testing.T) {
+	requireImagePushers(t)
+
+	// Pinned above 1: the assertions below read the buffered blocks, which a
+	// serial run does not produce.
+	t.Setenv(ImagePushConcurrencyEnvVar, "4")
+
+	dir := t.TempDir()
+	pushers := []string{
+		writePusher(t, dir, "ok0", "echo fine\n"),
+		writePusher(t, dir, "bad1", "echo boom >&2\nexit 3\n"),
+		writePusher(t, dir, "ok2", "echo fine\n"),
+		writePusher(t, dir, "bad3", "exit 4\n"),
+	}
+
+	var err error
+	stdout := captureStdout(t, func() {
+		err = RunImagePushers(pushers)
+	})
+
+	if err == nil {
+		t.Fatal("RunImagePushers() = nil, want an error")
+	}
+
+	// A failing pusher must not stop the others, and every failure must be
+	// reported rather than only the first.
+	for _, want := range []string{"bad1", "bad3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %s: %v", want, err)
+		}
+	}
+	if strings.Count(stdout, "Output from image pusher") != len(pushers) {
+		t.Errorf("not every pusher ran. Output:\n%s", stdout)
+	}
+
+	// A failing pusher's diagnostics have to survive the buffering.
+	if !strings.Contains(stdout, "boom") {
+		t.Errorf("failing pusher's stderr was dropped. Output:\n%s", stdout)
+	}
+}
+
+// At a concurrency of 1 there is nothing to protect the output from, so pushers
+// must write through live on their own streams instead of being captured and
+// replayed. This is what makes RULES_HELM_IMAGE_PUSH_CONCURRENCY=1 a true
+// fallback to the original serial behaviour.
+func TestRunImagePushersStreamsLiveWhenSerial(t *testing.T) {
+	requireImagePushers(t)
+
+	t.Setenv(ImagePushConcurrencyEnvVar, "1")
+
+	dir := t.TempDir()
+	pushers := []string{
+		writePusher(t, dir, "pusher0", "echo 'existing manifest: sha256:abc'\n"),
+		writePusher(t, dir, "pusher1", "echo 'existing manifest: sha256:def'\n"),
+	}
+
+	stdout := captureStdout(t, func() {
+		if err := RunImagePushers(pushers); err != nil {
+			t.Errorf("RunImagePushers() = %v, want nil", err)
+		}
+	})
+
+	for _, want := range []string{"sha256:abc", "sha256:def"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout is missing %s. Output:\n%s", want, stdout)
+		}
+	}
+
+	if strings.Contains(stdout, "Output from image pusher") {
+		t.Errorf("output was captured and replayed rather than streamed live. Output:\n%s", stdout)
+	}
+}

--- a/helm/private/install.bzl
+++ b/helm/private/install.bzl
@@ -145,7 +145,12 @@ def _helm_install_impl(ctx, subcommand = "install"):
     ]
 
 helm_install = rule(
-    doc = "Produce an executable for performing a `helm install` operation.",
+    doc = """\
+Produce an executable for performing a `helm install` operation.
+
+Any images bundled into `package` are pushed first, at most `RULES_HELM_IMAGE_PUSH_CONCURRENCY`
+(default `4`) at a time.
+""",
     implementation = _helm_install_impl,
     executable = True,
     attrs = {
@@ -202,7 +207,12 @@ def _helm_upgrade_impl(ctx):
     return _helm_install_impl(ctx, "upgrade")
 
 helm_upgrade = rule(
-    doc = "Produce an executable for performing a `helm upgrade` operation.",
+    doc = """\
+Produce an executable for performing a `helm upgrade` operation.
+
+Any images bundled into `package` are pushed first, at most `RULES_HELM_IMAGE_PUSH_CONCURRENCY`
+(default `4`) at a time.
+""",
     implementation = _helm_upgrade_impl,
     executable = True,
     attrs = {

--- a/helm/private/pusher/BUILD.bazel
+++ b/helm/private/pusher/BUILD.bazel
@@ -6,6 +6,5 @@ go_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//helm/private/helm_utils",
-        "@rules_go//go/runfiles",
     ],
 )

--- a/helm/private/pusher/pusher.go
+++ b/helm/private/pusher/pusher.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"log"
 	"os"
-	"os/exec"
 
-	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/periareon/rules_helm/helm/private/helm_utils"
 )
 
@@ -36,20 +34,7 @@ func main() {
 		log.Fatalf("Failed to read args file: %v", err)
 	}
 
-	r, err := runfiles.New()
-	if err != nil {
-		log.Fatalf("Unable to create runfiles: %v", err)
-	}
-
-	for _, pusher := range imagePushers {
-		cmd := exec.Command(pusher)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = append(os.Environ(), r.Env()...)
-
-		log.Printf("Running image pusher: %s", pusher)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("Failed to run image pusher %s: %v", pusher, err)
-		}
+	if err := helm_utils.RunImagePushers(imagePushers); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/helm/private/registrar/BUILD.bazel
+++ b/helm/private/registrar/BUILD.bazel
@@ -6,6 +6,5 @@ go_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//helm/private/helm_utils",
-        "@rules_go//go/runfiles",
     ],
 )

--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -8,11 +8,9 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/periareon/rules_helm/helm/private/helm_utils"
 )
 
@@ -160,22 +158,9 @@ func main() {
 		log.Printf("WARNING: A Helm registry password was set but no associated `HELM_REGISTRY_USERNAME` var was found. Skipping `helm registry login`.")
 	}
 
-	r, err := runfiles.New()
-	if err != nil {
-		log.Fatalf("Unable to create runfiles.")
-	}
-
 	// Subprocess image pushers
-	for _, pusher := range imagePushers {
-		cmd := exec.Command(pusher)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = append(os.Environ(), r.Env()...)
-
-		log.Printf("Running image pusher: %s", pusher)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("Failed to run image pusher %s: %v", pusher, err)
-		}
+	if err := helm_utils.RunImagePushers(imagePushers); err != nil {
+		log.Fatal(err)
 	}
 
 	// Pin the chart's mtime to the `created` timestamp from metadata.json,

--- a/helm/private/registry.bzl
+++ b/helm/private/registry.bzl
@@ -111,6 +111,10 @@ Before performing `helm push` the executable produced will conditionally perform
 if the following environment variables are defined:
 - `HELM_REGISTRY_USERNAME`: The value of `--username`.
 - `HELM_REGISTRY_PASSWORD`/`HELM_REGISTRY_PASSWORD_FILE`: The value of `--password` or a file containing the `--password` value.
+
+When `include_images` is True, the chart's images are pushed concurrently, at most
+`RULES_HELM_IMAGE_PUSH_CONCURRENCY` (default `4`) at a time. Set it to `1` to push them one at a
+time and stream each pusher's output live.
 """,
     implementation = _helm_push_impl,
     executable = True,
@@ -212,7 +216,12 @@ def _helm_push_images_impl(ctx):
     ]
 
 helm_push_images = rule(
-    doc = "Produce an executable for pushing all oci images used by a helm chart.",
+    doc = """\
+Produce an executable for pushing all oci images used by a helm chart.
+
+The images are pushed concurrently, at most `RULES_HELM_IMAGE_PUSH_CONCURRENCY` (default `4`) at a
+time. Set it to `1` to push them one at a time and stream each pusher's output live.
+""",
     implementation = _helm_push_images_impl,
     executable = True,
     attrs = {

--- a/helm/private/runner/BUILD.bazel
+++ b/helm/private/runner/BUILD.bazel
@@ -6,6 +6,5 @@ go_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//helm/private/helm_utils",
-        "@rules_go//go/runfiles",
     ],
 )

--- a/helm/private/runner/runner.go
+++ b/helm/private/runner/runner.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/periareon/rules_helm/helm/private/helm_utils"
 )
 
@@ -143,20 +142,9 @@ func main() {
 	}
 
 	// Subprocess image pushers.
-	if !is_test && len(imagePushers) > 0 {
-		r, err := runfiles.New()
-		if err != nil {
-			log.Fatalf("Failed to load runfiles: %v", err)
-		}
-		for _, pusher := range imagePushers {
-			cmd := exec.Command(pusher)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Env = append(os.Environ(), r.Env()...)
-
-			if err := cmd.Run(); err != nil {
-				log.Fatalf("Failed to run image pusher %s: %v", pusher, err)
-			}
+	if !is_test {
+		if err := helm_utils.RunImagePushers(imagePushers); err != nil {
+			log.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
A chart's image pushers ran one at a time. Each pusher is a separate process that re-does the registry auth handshake from scratch first thing, so the wall time scaled linearly with the image count even when every image was already present in the registry. An 11-image chart spent over a minute per `helm_upgrade` re-checking images it had already pushed.

Run the pushers concurrently, up to `RULES_HELM_IMAGE_PUSH_CONCURRENCY` (default 4). Set it to 1 to restore the previous serial behaviour.

Consequences:
  - Concurrent pushers writing to a shared stdout interleave line by line. Each pusher's output is buffered and flushed as one block, so a block always stays attributable to its pusher.
  - Failing on the first error would abandon pushers already in flight. Every pusher now runs to completion and the errors are joined, so a run reports all of its failures rather than only the earliest.
  
Test: ~15s with this, against ~68s with main.