### PR TITLE
fix(import): support relative URLs with paths in helm index.yaml

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,6 +97,7 @@ use_repo(
     "helm_test_deps__with_external_deps_karpenter",
     "helm_test_deps__with_external_deps_postgresql",
     "helm_test_deps__with_external_deps_redis",
+    "helm_test_deps__with_external_deps_trust_manager",
     "rules_helm_test_img_container_base",
     "rules_helm_test_oci_container_base",
 )

--- a/helm/private/import.bzl
+++ b/helm/private/import.bzl
@@ -52,12 +52,12 @@ def _find_chart_url(repository_ctx, repo_file, chart_name, chart_version):
         line = line.lstrip(" ")
         if line.startswith("-") and line.endswith(chart_file) or line.endswith(oci_identifier):
             url = line.lstrip("-").lstrip(" ")
-            if url == chart_file:
-                return "{}/{}".format(repository_ctx.attr.repository, url)
             if url.startswith("http") and url.endswith("/{}".format(chart_file)):
                 return url
             if url.startswith("oci") and url.endswith("/{}".format(oci_identifier)):
                 return url
+            if not url.startswith("http") and not url.startswith("oci"):
+                return "{}/{}".format(repository_ctx.attr.repository, url)
     fail("cannot find {} (version {}) in {}".format(chart_name, chart_version, repository_ctx.attr.repository))
 
 def _get_chart_file_name(chart_url):

--- a/tests/test_deps.bzl
+++ b/tests/test_deps.bzl
@@ -30,6 +30,16 @@ def helm_test_deps():
         sha256 = "4f70fc4c8caac66b21450581e29e3437cad401895d5ac0191e9e91f74ed8dc10",
     )
 
+    # Test downloading from a chart repository that uses relative URLs with paths in its index.yaml:
+    maybe(
+        helm_import_repository,
+        name = "helm_test_deps__with_external_deps_trust_manager",
+        repository = "https://charts.jetstack.io",
+        chart_name = "trust-manager",
+        version = "v0.24.0",
+        sha256 = "0de4bbef2d1a013bd4a91c6f59a9cb0273dda9a785e018a9a16e8f2b096af823",
+    )
+
     # Directly download this chart from a HTTP URL:
     maybe(
         helm_import_repository,

--- a/tests/with_external_deps/BUILD.bazel
+++ b/tests/with_external_deps/BUILD.bazel
@@ -12,6 +12,7 @@ helm_chart(
         "@helm_test_deps__with_external_deps_karpenter//:karpenter",
         "@helm_test_deps__with_external_deps_postgresql//:postgresql",
         "@helm_test_deps__with_external_deps_redis//:redis",
+        "@helm_test_deps__with_external_deps_trust_manager//:trust-manager",
     ],
 )
 

--- a/tests/with_external_deps/Chart.yaml
+++ b/tests/with_external_deps/Chart.yaml
@@ -43,3 +43,6 @@ dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 14.0.5
+  - name: trust-manager
+    repository: https://charts.jetstack.io
+    version: v0.24.0

--- a/tests/with_external_deps/with_external_deps_test.go
+++ b/tests/with_external_deps/with_external_deps_test.go
@@ -131,8 +131,8 @@ func TestWithChartDepsTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to load main Chart.yaml: %v", err)
 	}
-	if len(chart.Dependencies) != 6 {
-		t.Fatalf("Expected 6 dependencies in main Chart.yaml, but found %d", len(chart.Dependencies))
+	if len(chart.Dependencies) != 7 {
+		t.Fatalf("Expected 7 dependencies in main Chart.yaml, but found %d", len(chart.Dependencies))
 	}
 
 	expectedDeps := map[string]HelmChartDependency{
@@ -144,6 +144,7 @@ func TestWithChartDepsTest(t *testing.T) {
 		"cert-manager":   {Name: "cert-manager", Repository: "oci://quay.io/jetstack/charts", Version: "v1.19.4"},
 		"redis":          {Name: "redis", Repository: "https://charts.bitnami.com/bitnami", Version: "21.2.5"},
 		"postgresql":     {Name: "postgresql", Repository: "https://charts.bitnami.com/bitnami", Version: "14.0.5"},
+		"trust-manager":  {Name: "trust-manager", Repository: "https://charts.jetstack.io", Version: "v0.24.0"},
 	}
 
 	for _, dep := range chart.Dependencies {


### PR DESCRIPTION
The `_find_chart_url` function in `helm/private/import.bzl` evaluates a check (`url == chart_file`) that requires relative URLs in a Helm repository's `index.yaml` to equal the chart package filename. The Helm specification permits relative URLs to include subdirectory paths (e.g., `charts/mychart-1.0.0.tgz`). This causes
`helm_import_repository` to return an error when parsing repositories that use subdirectories.

Updates `_find_chart_url` to treat any URL that does not start with an absolute scheme (`http` or `oci`) as a relative URL, resolving it against the base repository URL.

The `trust-manager` chart from the Jetstack repository has been added to the `with_external_deps` integration test suite. Jetstack's `index.yaml` uses relative URLs with paths
(`charts/trust-manager-v0.24.0.tgz`) exercizing this new code path.